### PR TITLE
Update Readme.md: fix extraneous semicolons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ fullArchive('myArchive.7z', 'destination', { p: 'myPassword' } /* 7z options/swi
 // Equivalent to `on('data', function (files) { // ... });`
 .progress(function (files) {
   console.log('Some files are extracted: %s', files);
-});
+})
 
 // When all is done
 .then(function () {
   console.log('Extracting done!');
-});
+})
 
 // On error
 .catch(function (err) {


### PR DESCRIPTION
There were semicolons in the first snippet of code that weren't supposed to be there.